### PR TITLE
Fix telemetry warnings filter

### DIFF
--- a/a2a/crew_agent.py
+++ b/a2a/crew_agent.py
@@ -1,8 +1,20 @@
 import warnings
+import importlib
 
 # Suppress specific warnings
-warnings.filterwarnings("ignore", category=UserWarning, module="pydantic._internal._config")
-warnings.filterwarnings("ignore", category=UserWarning, module="crewai.telemtry.telemetry")
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    module="pydantic._internal._config",
+)
+
+if importlib.util.find_spec("crewai.telemetry.telemetry") is not None:
+    warnings.filterwarnings(
+        "ignore",
+        category=UserWarning,
+        module="crewai.telemetry.telemetry",
+    )
+
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="langchain")
 
 from fastapi import FastAPI, HTTPException


### PR DESCRIPTION
## Summary
- guard CrewAI telemetry warnings filter behind module existence
- fix spelling of `telemetry`

## Testing
- `python -m pytest`
- `python -m py_compile a2a/*.py`